### PR TITLE
Make YamlToArrayTransformer accept ValueObject as a wrapper

### DIFF
--- a/src/Transfer/Commons/Yaml/Worker/Transformer/YamlToArrayTransformer.php
+++ b/src/Transfer/Commons/Yaml/Worker/Transformer/YamlToArrayTransformer.php
@@ -10,6 +10,7 @@
 namespace Transfer\Commons\Yaml\Worker\Transformer;
 
 use Symfony\Component\Yaml\Parser;
+use Transfer\Data\ValueObject;
 use Transfer\Worker\WorkerInterface;
 
 class YamlToArrayTransformer implements WorkerInterface
@@ -19,6 +20,9 @@ class YamlToArrayTransformer implements WorkerInterface
      */
     public function handle($yaml)
     {
+        if($yaml instanceof ValueObject) {
+            $yaml = $yaml->data;
+        }
         if (!is_string($yaml)) {
             throw new \InvalidArgumentException(
                 sprintf('Expected argument #1 to be of type string, got %s', gettype($yaml))

--- a/src/Transfer/Commons/Yaml/Worker/Transformer/YamlToArrayTransformer.php
+++ b/src/Transfer/Commons/Yaml/Worker/Transformer/YamlToArrayTransformer.php
@@ -20,7 +20,7 @@ class YamlToArrayTransformer implements WorkerInterface
      */
     public function handle($yaml)
     {
-        if($yaml instanceof ValueObject) {
+        if ($yaml instanceof ValueObject) {
             $yaml = $yaml->data;
         }
         if (!is_string($yaml)) {


### PR DESCRIPTION
To be able to use transfer/transfer adapters which sends data wrapped in `Transfer\Data\ValueObject`.